### PR TITLE
feat: Update lora_basic_modem driver version

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -11,7 +11,7 @@ manifest:
     - name: lora_basics_modem
       path: modules/lib/lora_basics_modem
       url: https://github.com/IRNAS/SWL2001
-      revision: v0.1.0
+      revision: v0.2.0
 
   self:
     path: application


### PR DESCRIPTION
The `smtc_modem_connection_timeout_set_thresholds()`, function was removed from the `modem_api` in the `lora_basics_modem` driver.  A wrapper function was added to  `smtc_modem_api` to make `lorawan_api_set_no_rx_packet_threshold` accessible in the v0.2.0 release. 

This PR changes the driver revision.