### PR TITLE
feat: add user choice of trigger type

### DIFF
--- a/drivers/lora_lbm/Kconfig
+++ b/drivers/lora_lbm/Kconfig
@@ -55,7 +55,30 @@ config LORA_BASICS_MODEM_DRIVERS_EVENT_TRIGGER_DIRECT
 	depends on GPIO
 	select LORA_BASICS_MODEM_DRIVERS_EVENT_TRIGGER
 
-endchoice
+endchoice # LORA_BASICS_MODEM_DRIVERS_EVENT_TRIGGER
+
+choice
+	prompt "Event trigger type"
+	default LORA_BASICS_MODEM_DRIVERS_EVENT_TRIGGER_TYPE_EDGE_TO
+	help
+	  Specify the type of triggering to be used by the LORA_BASICS_MODEM_DRIVERS driver - edge to active/inactive or level active/inactive based.
+	  Driver operation will remain unchanged. There is a difference in power consumption of ~20 uA extra when using edge_to trigger.
+	  If LORA_BASICS_MODEM_DRIVERS_EVENT_TRIGGER_NONE is selected, set this to LORA_BASICS_MODEM_DRIVERS_EVENT_TRIGGER_TYPE_NONE.
+
+config LORA_BASICS_MODEM_DRIVERS_EVENT_TRIGGER_TYPE_NONE
+	bool "No trigger type"
+	help
+	  No trigger type is used, the driver will not use any event trigger. Should be set if LORA_BASICS_MODEM_DRIVERS_EVENT_TRIGGER_NONE is selected.
+
+config LORA_BASICS_MODEM_DRIVERS_EVENT_TRIGGER_TYPE_EDGE_TO
+	bool "Edge to active / inactive trigger"
+	depends on LORA_BASICS_MODEM_DRIVERS_EVENT_TRIGGER
+
+config LORA_BASICS_MODEM_DRIVERS_EVENT_TRIGGER_TYPE_LEVEL
+	bool "Level active/inactive trigger"
+	depends on LORA_BASICS_MODEM_DRIVERS_EVENT_TRIGGER
+
+endchoice # LORA_BASICS_MODEM_DRIVERS_EVENT_TRIGGER_TYPE
 
 config LORA_BASICS_MODEM_DRIVERS_EVENT_TRIGGER_THREAD_PRIORITY
 	int "Thread priority"

--- a/drivers/lora_lbm/lr11xx/lr11xx_board.c
+++ b/drivers/lora_lbm/lr11xx/lr11xx_board.c
@@ -42,7 +42,11 @@ static void lr11xx_board_event_callback(const struct device *dev, struct gpio_ca
 
 	if (gpio_pin_get_dt(&config->event)) {
 		/* Wait for value to drop */
-		gpio_pin_interrupt_configure_dt(&config->event, GPIO_INT_EDGE_TO_INACTIVE);
+#ifdef CONFIG_LORA_BASICS_MODEM_DRIVERS_EVENT_TRIGGER_TYPE_LEVEL
+		gpio_pin_interrupt_configure_dt(&config->event, GPIO_INT_LEVEL_INACTIVE);
+#elif CONFIG_LORA_BASICS_MODEM_DRIVERS_EVENT_TRIGGER_TYPE_EDGE_TO
+	gpio_pin_interrupt_configure_dt(&config->event, GPIO_INT_EDGE_TO_INACTIVE);
+#endif
 		/* Call provided callback */
 #ifdef CONFIG_LORA_BASICS_MODEM_DRIVERS_EVENT_TRIGGER_OWN_THREAD
 		k_sem_give(&data->gpio_sem);
@@ -54,7 +58,11 @@ static void lr11xx_board_event_callback(const struct device *dev, struct gpio_ca
 		}
 #endif
 	} else {
-		gpio_pin_interrupt_configure_dt(&config->event, GPIO_INT_EDGE_TO_ACTIVE);
+#ifdef CONFIG_LORA_BASICS_MODEM_DRIVERS_EVENT_TRIGGER_TYPE_LEVEL
+		gpio_pin_interrupt_configure_dt(&config->event, GPIO_INT_LEVEL_ACTIVE);
+#elif CONFIG_LORA_BASICS_MODEM_DRIVERS_EVENT_TRIGGER_TYPE_EDGE_TO
+	gpio_pin_interrupt_configure_dt(&config->event, GPIO_INT_EDGE_TO_ACTIVE);
+#endif
 	}
 }
 
@@ -95,7 +103,13 @@ void lora_transceiver_board_enable_interrupt(const struct device *dev)
 {
 #ifdef CONFIG_LORA_BASICS_MODEM_DRIVERS_EVENT_TRIGGER
 	const struct lr11xx_hal_context_cfg_t *config = dev->config;
+#ifdef CONFIG_LORA_BASICS_MODEM_DRIVERS_EVENT_TRIGGER_TYPE_LEVEL
+	gpio_pin_interrupt_configure_dt(&config->event, GPIO_INT_LEVEL_ACTIVE);
+#elif CONFIG_LORA_BASICS_MODEM_DRIVERS_EVENT_TRIGGER_TYPE_EDGE_TO
 	gpio_pin_interrupt_configure_dt(&config->event, GPIO_INT_EDGE_TO_ACTIVE);
+#else
+	LOG_ERR("Unsupported event trigger type!");
+#endif // CONFIG_LORA_BASICS_MODEM_DRIVERS_EVENT_TRIGGER_TYPE
 #else
 	LOG_ERR("Event trigger not supported!");
 #endif // CONFIG_LORA_BASICS_MODEM_DRIVERS_EVENT_TRIGGER


### PR DESCRIPTION
Add a user-configurable trigger type setting to optimize power consumption. There is ~20 uA power difference between level and edge-to based config.