### PR TITLE
Feat/update front end support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,12 @@
+Irnas v0.12.0
+============
+
+LoRa Basics Modem:
+* Modify front-end odule support for SX128X
+
+Radio drivers:
+* Modify external front-end odule support for SX128X. Add configuration options.
+
 Irnas v0.11.1
 ============
 

--- a/drivers/front_end_module.md
+++ b/drivers/front_end_module.md
@@ -1,0 +1,71 @@
+# Front-End-Module support
+
+We add Front-end-module support to the lora radio drivers, currently implemented only for `sx128X` radio. Implementation tries to introduce minimal changes to the radio drivers and `lora-basic-modem` lib.
+
+## Init
+
+To enable front-end-module support, user needs to set `CONFIG_LORA_BASIC_MODEM_EXTERNAL_FRONT_END_MODULE` in the project settings file. Then after radio driver is initialized, user needs to configure front-end-module via `lora_transceiver_configure_front_end_module()`, providing configuration
+
+```bash
+struct front_end_module_cfg_t {
+	struct front_end_module_cbs_t cbs;
+	uint8_t tx_pwr_threshold_dbm; /* Threshold above which the FEM should be set to TX mode */
+	uint8_t tx_max_pwr_dbm;       /* Maximum output power of the FEM in dB */
+	uint8_t gain_dbm;             /* Gain provided by the FEM in dB */
+    bool active;                  /* Whether to use the FEM */
+};
+```
+
+where `tx_pwr_threshold_dbm` defines dbm threshold, above which TX mode is selected over BYPASS, `tx_max_pwr_dbm` defines new max output power and `gain_dbm` is defined gain of the front-end-module. `active` flag determines if module should be use or not. All callbacks
+
+```bash
+struct front_end_module_cbs_t {
+	/**
+	 * @brief Turn off the front-end module.
+	 *
+	 */
+	void (*off)(void);
+	/**
+	 * @brief Set the front-end module in bypass mode.
+	 *
+	 */
+	void (*bypass)(void);
+	/**
+	 * @brief Set the front-end module in receive mode.
+	 *
+	 */
+	void (*rx)(void);
+	/**
+	 * @brief Set the front-end module in transmit mode.
+	 *
+	 */
+	void (*tx)(void);
+};
+```
+
+must be provided.
+
+## `lora_basic_modem` compatibility
+
+To make front-end module compatible with operation of the `lora_basic_modem`, before TX power is set via `sx128x_set_tx_params` call, `ral_sx128x_bsp_get_tx_cfg` must be called to check on power settings and make modifications based on the set power. This is already done in `lora_basic_modem`. If user is calling radio functions directly, it is his responsibility to call that.
+
+`ral_sx128x_bsp_get_tx_cfg` will check if there is support for front-end module and if it is configured. If not, only power limitations and board offset will be taken into the account when setting configured power, otherwise function will determine mode: bypass or TX and shift power setting for module gain in TX mode is selected.
+
+Before after setting TX parameters and before entering TX or RX mode, lbm lib will call `ral_sx128x_bsp_set_front_end_tx` or `ral_sx128x_bsp_set_front_end_rx`. `ral_sx128x_bsp_set_front_end_tx` will select correct mode (TX or BYPASS), provided lbm lib did a call to `ral_sx128x_bsp_get_tx_cfg` beforehand. Support is added to lbm lib.
+When TX or RX mode is done, `ral_sx128x_bsp_set_front_end_off` is called. This is implemented in the lbm lib set sleep and set standby functions.
+
+## Direct radio usage
+
+If user is calling radio functions directly, it is his responsibility to set correct front-end modes.
+
+### TX mode
+
+Call `ral_sx128x_bsp_get_tx_cfg` with desired parameters and use provided `tx_cfg_output_params.chip_output_pwr_in_dbm_configured` power to set power with `sx128x_set_tx_params` function.
+
+Turn on TX/BAYPASS mode based on desired power setting (`tx_cfg_input_params.system_output_pwr_in_dbm`). Set chip in TX mode with `sx128x_set_tx`.
+
+On TX done event, turn off front end module.
+
+### RX mode
+
+Turn on RX mode on front-end module before setting chip in RX mode with `sx128x_set_rx`. On RX done event or timeout, turn off front end module.

--- a/drivers/lora_lbm/Kconfig
+++ b/drivers/lora_lbm/Kconfig
@@ -92,9 +92,7 @@ config LORA_BASIC_MODEM_EXTERNAL_FRONT_END_MODULE
 	help
 	  Enable support for external front-end module (FEM) control in LoRa drivers.
 	  FEM will be automatically controlled during TX and RX operations if callbacks are provided.
-	  If enabled, user needs to provide callbacks trough lora_transceiver_set_front_end_module_cbs().
-	  Correct power offset must be defined in board file, or set at runtime with
-	  radio_utilities_set_tx_power_offset() function.
+	  If enabled, user needs to provide callbacks and configuration trough lora_transceiver_configure_front_end_module().
 
 # TODO: LORA_SHELL
 

--- a/drivers/lora_lbm/include/lora_lbm_transceiver.h
+++ b/drivers/lora_lbm/include/lora_lbm_transceiver.h
@@ -47,6 +47,18 @@ struct front_end_module_cbs_t {
 };
 
 /**
+ * @brief Front-end module configuration structure
+ *
+ */
+struct front_end_module_cfg_t {
+	struct front_end_module_cbs_t cbs;
+	uint8_t tx_pwr_threshold_dbm; /* Threshold above which the FEM should be set to TX mode */
+	uint8_t tx_max_pwr_dbm;       /* Maximum output power of the FEM in dB */
+	uint8_t gain_dbm;             /* Gain provided by the FEM in dB */
+	bool active;                  /* Whether to use the FEM */
+};
+
+/**
  * @brief Attach interrupt cb to event pin.
  *
  * @param dev context
@@ -87,10 +99,10 @@ int32_t lora_transceiver_get_model(const struct device *dev);
  * @brief Set front-end module callbacks
  *
  * @param[in] dev context
- * @param[in] fem_cbs front-end module callbacks
+ * @param[in] fem_cfg front-end module configuration
  */
-void lora_transceiver_set_front_end_module_cbs(const struct device *dev,
-	struct front_end_module_cbs_t fem_cbs);
+void lora_transceiver_configure_front_end_module(const struct device *dev,
+	struct front_end_module_cfg_t *fem_cfg);
 
 #ifdef __cplusplus
 }

--- a/drivers/lora_lbm/lora_lbm_transceiver.c
+++ b/drivers/lora_lbm/lora_lbm_transceiver.c
@@ -156,7 +156,7 @@ int32_t lora_transceiver_get_model(const struct device *dev)
 	return -1;
 }
 
-void lora_transceiver_set_front_end_module_cbs(const struct device *dev, struct front_end_module_cbs_t fem_cbs)
+void lora_transceiver_configure_front_end_module(const struct device *dev, struct front_end_module_cfg_t *fem_cfg)
 {
 #ifdef CONFIG_LORA_BASIC_MODEM_EXTERNAL_FRONT_END_MODULE
 	const radio_hal_context_type_t *context_type =
@@ -164,7 +164,7 @@ void lora_transceiver_set_front_end_module_cbs(const struct device *dev, struct 
 	switch (*context_type) {
 #ifdef CONFIG_SEMTECH_SX128X
 		case RADIO_HAL_CONTEXT_SX128X: {
-			sx128x_set_front_end_module_cbs(dev, fem_cbs);
+			sx128x_configure_front_end_module(dev, fem_cfg);
 			break;
 		}
 #endif /* CONFIG_SEMTECH_SX128X */

--- a/drivers/lora_lbm/sx128x/sx128x_board.c
+++ b/drivers/lora_lbm/sx128x/sx128x_board.c
@@ -137,11 +137,21 @@ uint32_t sx128x_get_tcxo_startup_delay_ms(const struct device *dev)
 	return 0;
 }
 
-void sx128x_set_front_end_module_cbs(const struct device *dev, struct front_end_module_cbs_t fem_cbs)
+void sx128x_configure_front_end_module(const struct device *dev, struct front_end_module_cfg_t *fem_cfg)
 {
 #ifdef CONFIG_LORA_BASIC_MODEM_EXTERNAL_FRONT_END_MODULE
+
+	__ASSERT(fem_cfg, "FEM configuration cannot be NULL");
+	__ASSERT(fem_cfg->tx_pwr_threshold_dbm <= SX128X_PWR_MAX, "FEM TX power threshold cannot be higher than max radio output power");
+	__ASSERT(fem_cfg->tx_pwr_threshold_dbm >= SX128X_PWR_MIN, "FEM TX power threshold cannot be lower than min radio output power");
+	__ASSERT(fem_cfg->tx_max_pwr_dbm >= SX128X_PWR_MAX, "FEM max TX power cannot be lower than max radio output power");
+	__ASSERT(fem_cfg->gain_dbm > 0, "FEM gain must be positive");
+
+
 	struct sx128x_hal_context_data_t *data = dev->data;
-	data->fem_cbs = fem_cbs;
+	data->fem_cfg = fem_cfg;
+#else
+	LOG_WRN("External front-end module support not enabled!");
 #endif /* CONFIG_LORA_BASIC_MODEM_EXTERNAL_FRONT_END_MODULE */
 }
 

--- a/drivers/lora_lbm/sx128x/sx128x_hal_context.h
+++ b/drivers/lora_lbm/sx128x/sx128x_hal_context.h
@@ -66,7 +66,8 @@ struct sx128x_hal_context_data_t {
 	sx128x_sleep_status_t radio_status;
 	uint8_t tx_offset; /* Board TX power offset at reset */
 #ifdef CONFIG_LORA_BASIC_MODEM_EXTERNAL_FRONT_END_MODULE
-	struct front_end_module_cbs_t fem_cbs;
+	struct front_end_module_cfg_t *fem_cfg;
+	bool fem_tx_mode; /* Whether to use TX or bypass mode for TX operations */
 #endif /* CONFIG_LORA_BASIC_MODEM_EXTERNAL_FRONT_END_MODULE */
 };
 
@@ -75,7 +76,7 @@ void sx128x_attach_interrupt(const struct device *dev, event_cb_t cb);
 void sx128x_enable_interrupt(const struct device *dev);
 void sx128x_disable_interrupt(const struct device *dev);
 uint32_t sx128x_get_tcxo_startup_delay_ms(const struct device *dev);
-void sx128x_set_front_end_module_cbs(const struct device *dev, struct front_end_module_cbs_t fem_cbs);
+void sx128x_configure_front_end_module(const struct device *dev, struct front_end_module_cfg_t *fem_cfg);
 
 #ifdef __cplusplus
 }

--- a/drivers/lora_lbm/sx128x/sx128x_ral_bsp.c
+++ b/drivers/lora_lbm/sx128x/sx128x_ral_bsp.c
@@ -25,28 +25,63 @@ void ral_sx128x_bsp_get_tx_cfg(const void* context,
 	const ral_sx128x_bsp_tx_cfg_input_params_t* input_params,
 	ral_sx128x_bsp_tx_cfg_output_params_t* output_params)
 {
-	// get board tx power offset
+	output_params->pa_ramp_time  = SX128X_RAMP_10_US;
+
+	// get board tx power offset and adjust input power accordingly
 	int8_t board_tx_pwr_offset_db = radio_utilities_get_tx_power_offset(context);
 
-	int16_t power = input_params->system_output_pwr_in_dbm - board_tx_pwr_offset_db;
+	int16_t power_expected = input_params->system_output_pwr_in_dbm - board_tx_pwr_offset_db;
 
-	if( power > SX128X_MAX_OUTPUT_POWER )
+	// Check if front-end module is available and configured and set power and mode accordingly
+#if CONFIG_LORA_BASIC_MODEM_EXTERNAL_FRONT_END_MODULE
+	const struct device *dev = context;
+	struct sx128x_hal_context_data_t *data = dev->data;
+	if (data->fem_cfg->active) {
+		int16_t power_configured = power_expected;
+		// Check min power
+		if( power_expected < SX128X_MIN_OUTPUT_POWER)
+		{
+			output_params->chip_output_pwr_in_dbm_configured = SX128X_MIN_OUTPUT_POWER;
+			output_params->chip_output_pwr_in_dbm_expected   = SX128X_MIN_OUTPUT_POWER;
+			data->fem_tx_mode = false; /* Set in bypass mode */
+		}
+		// Check if under FEM threshold
+		else if( power_expected <= data->fem_cfg->tx_pwr_threshold_dbm )
+		{
+			output_params->chip_output_pwr_in_dbm_configured = power_expected;
+			output_params->chip_output_pwr_in_dbm_expected   = power_expected;
+			data->fem_tx_mode = false; /* Set in bypass mode */
+		}
+		// FEM TX mode
+		else {
+			// Check if over max configured value
+			if( power_expected > data->fem_cfg->tx_max_pwr_dbm )
+			{
+				power_expected = data->fem_cfg->tx_max_pwr_dbm;
+			}
+			// Calculate set power with FEM gain compensation
+			power_configured = power_expected - data->fem_cfg->gain_dbm;
+			data->fem_tx_mode = true; /* Set in TX mode */
+
+			output_params->chip_output_pwr_in_dbm_configured = power_configured;
+			output_params->chip_output_pwr_in_dbm_expected   = power_expected;
+		}
+
+		return;
+	}
+#endif /* CONFIG_LORA_BASIC_MODEM_EXTERNAL_FRONT_END_MODULE */
+
+
+	if( power_expected > SX128X_MAX_OUTPUT_POWER )
 	{
 		output_params->chip_output_pwr_in_dbm_configured = SX128X_MAX_OUTPUT_POWER;
 		output_params->chip_output_pwr_in_dbm_expected   = SX128X_MAX_OUTPUT_POWER;
 	}
-	else if( power < SX128X_MIN_OUTPUT_POWER )
+	else if( power_expected < SX128X_MIN_OUTPUT_POWER )
 	{
 		output_params->chip_output_pwr_in_dbm_configured = SX128X_MIN_OUTPUT_POWER;
 		output_params->chip_output_pwr_in_dbm_expected   = SX128X_MIN_OUTPUT_POWER;
 	}
-	else
-	{
-		output_params->chip_output_pwr_in_dbm_configured = ( int8_t ) power;
-		output_params->chip_output_pwr_in_dbm_expected   = ( int8_t ) power;
-	}
-
-	output_params->pa_ramp_time  = SX128X_RAMP_10_US;
 }
 
 void ral_sx128x_bsp_get_lora_cad_det_peak(const void *context, ral_lora_sf_t sf, ral_lora_bw_t bw,
@@ -290,8 +325,20 @@ void ral_sx128x_bsp_set_front_end_tx(const void* context)
 #ifdef CONFIG_LORA_BASIC_MODEM_EXTERNAL_FRONT_END_MODULE
 	const struct device *dev = context;
 	struct sx128x_hal_context_data_t *data = dev->data;
-	if (data->fem_cbs.tx) {
-		data->fem_cbs.tx();
+	// Check if active
+	if(!data->fem_cfg->active) {
+		return;
+	}
+	// Determine whether to set FEM in TX mode or bypass mode based on configuration and expected output power
+	if(data->fem_tx_mode) {
+		if (data->fem_cfg->cbs.tx) {
+			data->fem_cfg->cbs.tx();
+		}
+	}
+	else {
+		if (data->fem_cfg->cbs.bypass) {
+			data->fem_cfg->cbs.bypass();
+		}
 	}
 #endif
 }
@@ -301,19 +348,12 @@ void ral_sx128x_bsp_set_front_end_rx(const void* context)
 #ifdef CONFIG_LORA_BASIC_MODEM_EXTERNAL_FRONT_END_MODULE
 	const struct device *dev = context;
 	struct sx128x_hal_context_data_t *data = dev->data;
-	if (data->fem_cbs.rx) {
-		data->fem_cbs.rx();
+	// Check if active
+	if(!data->fem_cfg->active) {
+		return;
 	}
-#endif
-}
-
-void ral_sx128x_bsp_set_front_end_bypass(const void* context)
-{
-#ifdef CONFIG_LORA_BASIC_MODEM_EXTERNAL_FRONT_END_MODULE
-	const struct device *dev = context;
-	struct sx128x_hal_context_data_t *data = dev->data;
-	if (data->fem_cbs.bypass) {
-		data->fem_cbs.bypass();
+	if (data->fem_cfg->cbs.rx) {
+		data->fem_cfg->cbs.rx();
 	}
 #endif
 }
@@ -323,8 +363,12 @@ void ral_sx128x_bsp_set_front_end_off(const void* context)
 #ifdef CONFIG_LORA_BASIC_MODEM_EXTERNAL_FRONT_END_MODULE
 	const struct device *dev = context;
 	struct sx128x_hal_context_data_t *data = dev->data;
-	if (data->fem_cbs.off) {
-		data->fem_cbs.off();
+	// Check if active
+	if(!data->fem_cfg->active) {
+		return;
+	}
+	if (data->fem_cfg->cbs.off) {
+		data->fem_cfg->cbs.off();
 	}
 #endif
 }

--- a/west.yml
+++ b/west.yml
@@ -11,7 +11,7 @@ manifest:
     - name: lora_basics_modem
       path: modules/lib/lora_basics_modem
       url: https://github.com/IRNAS/SWL2001
-      revision: v0.8.1
+      revision: v0.9.0
 
   self:
     path: application


### PR DESCRIPTION
Modify external front-end module support. 

**Changes:**

- Add configuration parameters alongside front-end module callbacks to be set by the user.
- Modify `ral_sx128x_bsp_get_tx_cfg` function to take into account front-end module settings and modify power settings accordingly.
- Modify front-end module interface functions so that TX/BAYPSS mode is set automatically, based on the power settings.
- Add brief documentation.